### PR TITLE
compatibility with large ciphers

### DIFF
--- a/resources/db_setup.default.sql
+++ b/resources/db_setup.default.sql
@@ -35,11 +35,11 @@ CREATE TABLE `vaultage_users` (
 CREATE TABLE `vaultage_data` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `data` text CHARACTER SET utf8 NOT NULL,
+  `data` longtext CHARACTER SET utf8 NOT NULL,
   `last_hash` varchar(64) NOT NULL,
   `user_id` int(11) NOT NULL,
   PRIMARY KEY ( id ), 
-  FOREIGN KEY (user_id) REFERENCES vaultage_users(id) 
+  FOREIGN KEY (user_id) REFERENCES vaultage_users(id) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1;
 
 
@@ -47,5 +47,5 @@ CREATE TABLE `vaultage_data` (
 -- Default data
 --
 
--- Adds the demo user (demo/demo1)
+-- Adds the default user
 INSERT INTO `vaultage_users` (`id`, `username`, `salt`, `remote_key`, `updated`) VALUES (NULL, '${USERNAME}', '${SALT}', NULL, NULL);

--- a/server/handlers.php
+++ b/server/handlers.php
@@ -21,6 +21,9 @@ function push_handler() {
         Cipher::update($user['id'], $_POST['data'], $_POST['new_hash'], $_POST['last_hash']);
 
         $cipher = Cipher::get_last($user['id']);
+        if ($cipher == null) {
+            end_with_json(array('error' => true, 'desc' => 'cannot fetch cipher'));
+        }
 
         backup($cipher['data']);
         end_with_json(array('error' => false, 'data' => $cipher['data']));
@@ -36,6 +39,9 @@ function changekey_handler() {
         Cipher::update($user['id'], $_POST['data'], $_POST['new_hash'], $_POST['last_hash']);
 
         $cipher = Cipher::get_last($user['id']);
+        if ($cipher == null) {
+            end_with_json(array('error' => true, 'desc' => 'cannot fetch cipher'));
+        }
         User::update_key($user, $_POST['update_key']);
 
         backup($cipher['data']);


### PR DESCRIPTION
- Allow larger ciphers in SQL DB
- Do not keep a record of previous ciphers
  to minimize the risk of DB overloading

closes #81 