### PR TITLE
Add "-d" option, harden integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ packages/vaultage-ui-webcli: packages/vaultage-client
 .PHONY: serve
 serve:
 	$(MAKE) build
+	$(MAKE) -C packages/vaultage clean-storage
 	$(MAKE) -C packages/vaultage serve
 
 .PHONY: integration-test

--- a/packages/vaultage/.gitignore
+++ b/packages/vaultage/.gitignore
@@ -3,3 +3,4 @@ coverage
 dist
 cipher.json
 config.json
+.data

--- a/packages/vaultage/Makefile
+++ b/packages/vaultage/Makefile
@@ -1,5 +1,6 @@
 BIN=dist/src/main.js
 SRC=$(shell find src/ -type f -name '*.ts')
+DATA_DIR=.data
 
 # Mandatory tasks (imposed by the top-level Makefile)
 
@@ -26,6 +27,10 @@ $(BIN): node_modules $(SRC)
 node_modules: package.json package-lock.json
 	npm install
 
+.PHONY: clean-storage
+clean-storage:
+	rm -rf $(DATA_DIR)
+
 .PHONY: serve
 serve: $(BIN)
-	npm start
+	npm start -- -d $(DATA_DIR)

--- a/packages/vaultage/src/tools/initConfig.ts
+++ b/packages/vaultage/src/tools/initConfig.ts
@@ -7,8 +7,14 @@ import { CONFIG_FILENAME } from '../constants';
 
 const SALTS_LENGTH = 64;
 
-export function storagePath(fileName: string): string {
-    const vaultageConfigDir = path.join(require('os').homedir(), '.vaultage');
+/**
+ * Returns the absolute path to some file in the storage directory.
+ *
+ * @param fileName File to search
+ * @param override Force a different storage path than the default
+ */
+export function storagePath(fileName: string, override: string | undefined): string {
+    const vaultageConfigDir = override != null ? override : path.join(require('os').homedir(), '.vaultage');
 
     if (!fs.existsSync(vaultageConfigDir)) {
         fs.mkdirSync(vaultageConfigDir);
@@ -17,7 +23,7 @@ export function storagePath(fileName: string): string {
     return path.join(vaultageConfigDir, fileName);
 }
 
-export function initConfig(): Promise<void> {
+export function initConfig(customStorage: string | undefined): Promise<void> {
     return new Promise((resolve, reject) => {
 
         // Get random bytes for salts generation.
@@ -38,7 +44,7 @@ export function initConfig(): Promise<void> {
                 }
             };
 
-            const configPath = storagePath(CONFIG_FILENAME);
+            const configPath = storagePath(CONFIG_FILENAME, customStorage);
             fs.writeFile(configPath, JSON.stringify(config), { encoding: 'utf-8' }, (err2) => {
                 if (err2) {
                     return reject(err2);


### PR DESCRIPTION
- Add "-d" option to select data directory
- Use "-d" option to run integration-test more cleanly
- Fix dangling process issues with integration-test

close #168 